### PR TITLE
Simplifications

### DIFF
--- a/joblib/_compat.py
+++ b/joblib/_compat.py
@@ -11,3 +11,8 @@ try:
 except NameError:
     _basestring = str
     _bytes_or_unicode = (bytes, str)
+
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    return meta("NewBase", bases, {})

--- a/joblib/_parallel_backends.py
+++ b/joblib/_parallel_backends.py
@@ -45,7 +45,7 @@ class ParallelBackendBase(with_metaclass(ABCMeta)):
     def apply_async(self, func, callback=None):
         """Schedule a func to be run"""
 
-    def initialize(self, n_jobs, poolargs):
+    def initialize(self, n_jobs, backend_args):
         """Build a process or thread pool and return the number of workers"""
         return self.effective_n_jobs(n_jobs)
 
@@ -124,7 +124,7 @@ class ThreadingBackend(PoolManagerMixin, ParallelBackendBase):
     "with nogil" block or an expensive call to a library such as NumPy).
     """
 
-    def initialize(self, n_jobs, poolargs):
+    def initialize(self, n_jobs, backend_args):
         """Build a process or thread pool and return the number of workers"""
         self._pool = ThreadPool(n_jobs)
         return n_jobs
@@ -160,7 +160,7 @@ class MultiprocessingBackend(PoolManagerMixin, ParallelBackendBase):
 
         return PoolManagerMixin.effective_n_jobs(self, n_jobs)
 
-    def initialize(self, n_jobs, poolargs):
+    def initialize(self, n_jobs, backend_args):
         """Build a process or thread pool and return the number of workers"""
         already_forked = int(os.environ.get(JOBLIB_SPAWNED_PROCESS, 0))
         if already_forked:
@@ -177,7 +177,7 @@ class MultiprocessingBackend(PoolManagerMixin, ParallelBackendBase):
 
         # Make sure to free as much memory as possible before forking
         gc.collect()
-        self._pool = MemmapingPool(n_jobs, **poolargs)
+        self._pool = MemmapingPool(n_jobs, **backend_args)
 
         # Batching counters
         self._effective_batch_size = 1

--- a/joblib/pool.py
+++ b/joblib/pool.py
@@ -318,11 +318,12 @@ class CustomizablePicklingQueue(object):
     pickling reducers, for instance to avoid memory copy when passing
     memory mapped datastructures.
 
-    `reducers` is expected to be a dictionary with key/values
-    being `(type, callable)` pairs where `callable` is a function that, given an
+    `reducers` is expected to be a dict with key / values being
+    `(type, callable)` pairs where `callable` is a function that, given an
     instance of `type`, will return a tuple `(constructor, tuple_of_objects)`
     to rebuild an instance out of the pickled `tuple_of_objects` as would
     return a `__reduce__` method.
+
     See the standard library documentation on pickling for more details.
     """
 

--- a/joblib/test/test_parallel.py
+++ b/joblib/test/test_parallel.py
@@ -108,7 +108,8 @@ def check_simple_parallel(backend):
     for n_jobs in (1, 2, -1, -2):
         assert_equal(
             [square(x) for x in X],
-            Parallel(n_jobs=n_jobs)(delayed(square)(x) for x in X))
+            Parallel(n_jobs=n_jobs, backend=backend)(
+                delayed(square)(x) for x in X))
     try:
         # To smoke-test verbosity, we capture stdout
         orig_stdout = sys.stdout


### PR DESCRIPTION
Provide default implementation for common methods instead of making every method of the ABC an abstractmethod.

Ensure that ABCMeta is enabled under Python 3.

Also change code style to be more in line with PEP8 / PEP257.

Rename `Parallel._pool` to `Parallel._backend` for naming consistency.

This is a PR against joblib/joblib#306.
